### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,8 +27,11 @@ jobs:
           libncurses5-dev libncursesw5-dev libreadline-dev libbz2-dev liblzma-dev
         pip install cython
 
-    - name: Install Buildozer
-      run: pip install --upgrade buildozer
+      - name: Install Buildozer
+        run: pip install --upgrade buildozer
+
+      - name: Prepare buildozer spec
+        run: cp .github/buildozer.spec buildozer.spec
 
     - name: Install Android Command-Line Tools
       run: |


### PR DESCRIPTION
## Summary
- fix build workflow by copying the spec file before running buildozer

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6847dc53ef208330aa98e214ab3a90e0