### PR TITLE
Fix relations and reporting; add migration for row_version and soft deletes

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\BorrowRequest;
 use App\Models\DamageReport;
+use App\Models\RepairJob;
 use App\Models\Tool;
 
 class DashboardController extends Controller
@@ -20,7 +21,7 @@ class DashboardController extends Controller
             'overdue' => BorrowRequest::whereIn('status', ['APPROVED_FINAL', 'DISPATCHED'])
                 ->whereDate('planned_return_at', '<', now()->toDateString())
                 ->count(),
-            'repairCostMonth' => DamageReport::whereMonth('created_at', now()->month)->sum('repair_cost_idr'),
+            'repairCostMonth' => RepairJob::whereMonth('created_at', now()->month)->sum('repair_cost_idr'),
         ]);
     }
 }

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -63,8 +63,9 @@ class ReportController extends Controller
                     'Usulan Tindak Lanjut', 'Progress Perbaikan', 'Nama Mitra/Swakelola', 'Tanggal Kirim', 'Surat Jalan Kirim',
                     'Rencana Kembali', 'Nilai Perbaikan', 'Tanggal Terima', 'Surat Jalan Terima', 'Hasil Akhir', 'Status', 'Keterangan'
                 ]);
-                DamageReport::with(['tool', 'workType', 'reporter'])->chunk(200, function ($rows) use ($handle) {
+                DamageReport::with(['tool', 'workType', 'reporter', 'repairJob.vendor'])->chunk(200, function ($rows) use ($handle) {
                     foreach ($rows as $row) {
+                        $repairJob = $row->repairJob;
                         fputcsv($handle, [
                             $row->ticket_no,
                             optional($row->reported_at)->format('d-M-Y'),
@@ -79,15 +80,15 @@ class ReportController extends Controller
                             $row->priority,
                             $row->verification_result,
                             $row->recommendation,
-                            $row->progress,
-                            $row->vendor_name,
-                            optional($row->sent_at)->format('d-M-Y'),
-                            $row->surat_jalan_repair_kirim,
-                            optional($row->planned_return_at)->format('d-M-Y'),
-                            $row->repair_cost_idr,
-                            optional($row->received_at)->format('d-M-Y'),
-                            $row->surat_jalan_repair_terima,
-                            $row->hasil_akhir,
+                            $repairJob?->progress_status,
+                            $repairJob?->vendor?->vendor_name,
+                            optional($repairJob?->sent_at)->format('d-M-Y'),
+                            $repairJob?->surat_jalan_kirim,
+                            optional($repairJob?->planned_finish_at)->format('d-M-Y'),
+                            $repairJob?->repair_cost_idr,
+                            optional($repairJob?->received_at)->format('d-M-Y'),
+                            $repairJob?->surat_jalan_terima,
+                            $repairJob?->hasil_akhir,
                             $row->status,
                             $row->remark,
                         ]);

--- a/app/Models/BorrowRequest.php
+++ b/app/Models/BorrowRequest.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class BorrowRequest extends BaseModel
 {
@@ -36,13 +37,13 @@ class BorrowRequest extends BaseModel
         return $this->hasMany(BorrowItem::class);
     }
 
-    public function shipment(): BelongsTo
+    public function shipment(): HasOne
     {
-        return $this->belongsTo(Shipment::class, 'id', 'borrow_request_id');
+        return $this->hasOne(Shipment::class, 'borrow_request_id');
     }
 
-    public function returnEntry(): BelongsTo
+    public function returnEntry(): HasOne
     {
-        return $this->belongsTo(ReturnEntry::class, 'id', 'borrow_request_id');
+        return $this->hasOne(ReturnEntry::class, 'borrow_request_id');
     }
 }

--- a/app/Models/DamageReport.php
+++ b/app/Models/DamageReport.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class DamageReport extends BaseModel
 {
@@ -28,5 +29,10 @@ class DamageReport extends BaseModel
     public function reporter(): BelongsTo
     {
         return $this->belongsTo(User::class, 'reported_by_user_id');
+    }
+
+    public function repairJob(): HasOne
+    {
+        return $this->hasOne(RepairJob::class);
     }
 }

--- a/database/migrations/2024_01_02_000004_add_row_versions_and_soft_deletes.php
+++ b/database/migrations/2024_01_02_000004_add_row_versions_and_soft_deletes.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    private array $rowVersionTables = [
+        'roles',
+        'area_units',
+        'users',
+        'tool_categories',
+        'tool_locations',
+        'work_types',
+        'vendors',
+        'holidays',
+        'sla_settings',
+        'escalation_matrix',
+        'attachments',
+        'audit_logs',
+        'event_logs',
+        'correction_notes',
+        'borrow_items',
+        'shipments',
+        'returns',
+        'return_items',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->rowVersionTables as $table) {
+            if (!Schema::hasColumn($table, 'row_version')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->unsignedInteger('row_version')->default(1);
+                });
+            }
+        }
+
+        foreach (['audit_logs', 'event_logs', 'correction_notes'] as $table) {
+            if (!Schema::hasColumn($table, 'deleted_at')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->softDeletes();
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (['audit_logs', 'event_logs', 'correction_notes'] as $table) {
+            if (Schema::hasColumn($table, 'deleted_at')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->dropSoftDeletes();
+                });
+            }
+        }
+
+        foreach ($this->rowVersionTables as $table) {
+            if (Schema::hasColumn($table, 'row_version')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->dropColumn('row_version');
+                });
+            }
+        }
+    }
+};


### PR DESCRIPTION
### Motivation

- Correct model relations where `borrow_requests` should `hasOne` related `shipments` and `returns` instead of misplaced `belongsTo` links.
- Surface repair job information in reporting and dashboard aggregates because repair metadata (cost, vendor, progress) lives on `repair_jobs` not directly on `damage_reports`.
- Ensure `BaseModel` optimistic concurrency (`row_version`) behavior and soft deletes are supported across auxiliary tables by adding missing columns.
- Make exports and UI metrics consistent with the actual database shape so CSVs and dashboard numbers reflect real data.

### Description

- Changed `shipment()` and `returnEntry()` on `app/Models/BorrowRequest.php` from `belongsTo` to `hasOne` and corrected the foreign key usage to `borrow_request_id`.
- Added a `repairJob()` `HasOne` relation to `app/Models/DamageReport.php` so damage reports can reference their repair job.
- Updated `app/Http/Controllers/ReportController.php` to eager-load `repairJob.vendor` and emit repair-job fields (e.g. `progress_status`, `vendor_name`, `sent_at`, `planned_finish_at`, `repair_cost_idr`, `received_at`, `surat_jalan_terima`, `hasil_akhir`) in the damage export.
- Updated `app/Http/Controllers/DashboardController.php` to calculate monthly repair cost from `RepairJob::whereMonth(...)->sum('repair_cost_idr')` and added a migration `database/migrations/2024_01_02_000004_add_row_versions_and_soft_deletes.php` to add `row_version` columns and `deleted_at` (soft deletes) for selected tables.

### Testing

- No automated tests were executed as part of this change.
- Basic static checks: files modified and migration created and committed successfully.
- Migration adds columns conditionally using `Schema::hasColumn` to avoid failures on re-run.
- Manual runtime/integration tests are recommended (run `php artisan migrate` and exercise exports/dashboards) but were not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69533ce4b91083309f842af37263d93b)